### PR TITLE
Export poster services

### DIFF
--- a/services/poster.go
+++ b/services/poster.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"time"
 
 	"github.com/anacrolix/ffprobe"
 	"github.com/anacrolix/missinggo"
@@ -83,6 +84,18 @@ func (me *posterInstance) defaultGetInfo(ctx context.Context, source string) (in
 	return
 }
 
+func (me *posterInstance) Duration(ctx context.Context) (time.Duration, error) {
+	info, err := me.getInfo(ctx, me.input)
+	if err != nil {
+		return 0, err
+	}
+	d, err := info.Duration()
+	if err != nil {
+		return 0, fmt.Errorf("getting duration from info: %w", err)
+	}
+	return d, nil
+}
+
 func (me *posterInstance) getInfo(ctx context.Context, source string) (ffprobe.Info, error) {
 	if me.customGetInfo != nil {
 		return me.customGetInfo(ctx)
@@ -91,11 +104,7 @@ func (me *posterInstance) getInfo(ctx context.Context, source string) (ffprobe.I
 }
 
 func (me *posterInstance) ssArg(ctx context.Context, source string) (ss string, err error) {
-	info, err := me.getInfo(ctx, source)
-	if err != nil {
-		return
-	}
-	d, err := info.Duration()
+	d, err := me.Duration(ctx)
 	if err != nil {
 		return "", fmt.Errorf("getting duration from info: %w", err)
 	}


### PR DESCRIPTION
This allows usage of [poster.go](https://github.com/anacrolix/webtorrent-public/pull/1/files#diff-a30e6ed71c9c3fbf693fa8dd1b69ab8b2a5eed58dc49e4805cb1e4ff93c56b15) by other libraries as such:

```go

import "github.com/anacrolix/torrent"
import "github.com/pkg/errors" // Not necessary, but produces nice context to errors

func fetchTorrentThumbnailAndDuration(
	ctx context.Context,
	torrentClient *torrent.Torrent,
) (thumbnailFile *os.File, durationFile *os.File, err error) {
	aTorrent, err := torrent.AddMagnet(self.magnetLink)
	if err != nil {
		return nil, nil, errors.Wrap(err, "")
	}
	select {
	case <-aTorrent.GotInfo():
	case <-ctx.Done():
		return nil, nil, errors.Wrap(ctx.Err(), "")
	}

	torrentFile := aTorrent.Files()[self.fileIndex]
	// Start a web service listener to serve torrent files
	l, err := net.Listen("tcp", "localhost:0")
	if err != nil {
		return nil, nil, errors.Wrap(err, "listening for input http server")
	}
	defer l.Close()
	inputServer := http.Server{
		Handler: torrentFileServer{torrentFile},
	}
	go inputServer.Serve(l)
	defer inputServer.Close()

	// Create a new Poster instance to receive torrent files
	poster := services.NewPosterInstance("http://" + l.Addr().String())

	// Create an empty file so Poster can fill it with the thumbnail
	thumbnailFile, err = ioutil.TempFile("", "")
	if err != nil {
		return nil, nil, errors.Wrap(err, "creating output thumbnail file")
	}

	// This is where the blocking thumbnail fetching occurs
	err = poster.WriteTo(ctx, thumbnailFile)
	if err != nil {
		return nil, nil, errors.Wrapf(err,
			"writing out thumbnail for %q", torrentFile.DisplayPath())
	}
	thumbnailSize, err := thumbnailFile.Seek(0, io.SeekEnd)
	if err != nil {
		return nil, nil, errors.Wrap(err, "Error seeking")
	}
	if thumbnailSize == 0 {
		return nil, nil, errors.New("produced thumbnail with size 0")
	}
	_, err = thumbnailFile.Seek(0, io.SeekStart)
	if err != nil {
		return nil, nil, errors.Wrap(err, "Error seeking")
	}

	// Fetch duration
	duration, err := poster.Duration(ctx)
	if err != nil {
		return nil, nil, errors.Wrapf(err,
			"Fetching duration for %q", torrentFile.DisplayPath())
	}

	// Write duration's float64 to the duration file
	durationFile, err = ioutil.TempFile("", "")
	if err != nil {
		return nil, nil, errors.Wrap(err, "creating output duration file")
	}
	var durationAsBytes [8]byte
	binary.BigEndian.PutUint64(durationAsBytes[:], math.Float64bits(duration.Seconds()))
	err = os.WriteFile(durationFile.Name(), durationAsBytes[:], os.ModePerm)
	if err != nil {
		return nil, nil, errors.Wrapf(err,
			"writing out duration for %q", torrentFile.DisplayPath())
	}

	return thumbnailFile, durationFile, nil
}
```

/CC @anacrolix 